### PR TITLE
Pin links to docs to foot of sidebar

### DIFF
--- a/svelte-docsite/src/components/Logo.svelte
+++ b/svelte-docsite/src/components/Logo.svelte
@@ -1,4 +1,6 @@
 <script>
+  import transitions from '../transitions.js'
+  import {transition} from '../store.js'
   import {GithubSVG} from '../icons.js'
 
 	export let backdrop = false
@@ -23,6 +25,18 @@
     </a>
     Drop-in CSS transitions
   </p>
+
+  <select bind:value={$transition} class="mobile-only">
+    {#each Object.entries(transitions) as [title, groupedByShape]}
+      {#each Object.entries(groupedByShape) as [direction, groupedByDirection]}
+        <optgroup label="{title} {direction}">
+        {#each groupedByDirection as txn}
+          <option>{txn}</option>
+        {/each}
+        </optgroup>
+      {/each}
+    {/each}
+  </select>
 </header>
 
 <style>
@@ -74,6 +88,20 @@
     }
   }
 
+  header {
+    display: grid;
+    gap: 1.5ch;
+    justify-content: flex-start;
+  }
+
+  select {
+    width: min(100%, 300px);
+    margin: 3rem auto;
+    border: none;
+    font-size: 1.25rem;
+    background: var(--white);
+  }
+
   p {
     display: inline-flex;
     gap: 1ch;
@@ -102,6 +130,11 @@
   @media (max-width: 400px) {
     p {
       font-size: 6vmin;
+    }
+  }
+  @media (min-width: 1000px) {
+    select {
+      display: none;
     }
   }
 </style>

--- a/svelte-docsite/src/components/Sidebar.svelte
+++ b/svelte-docsite/src/components/Sidebar.svelte
@@ -33,68 +33,62 @@
 </script>
 
 <nav>
-  <select bind:value={$transition} class="mobile-only">
-    {#each Object.entries(transitions) as [title, groupedByShape]}
-      {#each Object.entries(groupedByShape) as [direction, groupedByDirection]}
-        <optgroup label="{title} {direction}">
-        {#each groupedByDirection as txn}
-          <option>{txn}</option>
-        {/each}
-        </optgroup>
-      {/each}
-    {/each}
-  </select>
+  <div class="nav__transitions">
+    <a class="getting-started" href="https://github.com/argyleink/transition.css#basics">Get Started ↗</a>
 
-  <a class="getting-started" href="https://github.com/argyleink/transition.css#basics">Get Started ↗</a>
-
-  <a class="fork-on-github" href="https://github.com/argyleink/transition.css">
-    <img loading="lazy" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_white_ffffff.png?resize=149%2C149" class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1">
-  </a>
-
-  <h3>Settings</h3>
-  <h4>--transition__duration:</h4>
-  <div>
-    <select bind:value={$duration}>
-      {#each [0.5,0.75,1,1.5,2,2.5,3,4,5,6,7,10] as time}
-        <option value={time}>{time}s</option>  
-      {/each}
-    </select>
-  </div>
-
-  <h4>--transition__easing:</h4>
-  <div>
-    <select bind:value={$easing}>
-      {#each easings as ez}
-        <option value={ez}>{ez}</option>  
-      {/each}
-    </select>
-  </div>
-
-  {#each Object.entries(transitions) as [title, groupedByShape]}
-    <h3>{title}</h3>
-    <dl>
-      {#each Object.entries(groupedByShape) as [direction, groupedByDirection]}
-        <dt>{direction}</dt>
-        {#each groupedByDirection as txn}
-          <dd selected={txn === transition}>
-            <a href="#{txn}" on:click={transitionClick}>{txn}</a>
-          </dd>
-        {/each}
-      {/each}
-    </dl>
-  {/each}
-
-  <div class="icon-break">
-    <a href="https://github.com/argyleink/transition.css">
-      <svg viewbox="0 0 512 512">
-        {@html GithubSVG}
-      </svg>
+    <a class="fork-on-github" href="https://github.com/argyleink/transition.css">
+      <img loading="lazy" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_white_ffffff.png?resize=149%2C149" class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1">
     </a>
+
+    <h3>Settings</h3>
+    <h4>--transition__duration:</h4>
+    <div>
+      <select bind:value={$duration}>
+        {#each [0.5,0.75,1,1.5,2,2.5,3,4,5,6,7,10] as time}
+          <option value={time}>{time}s</option>  
+        {/each}
+      </select>
+    </div>
+
+    <h4>--transition__easing:</h4>
+    <div>
+      <select bind:value={$easing}>
+        {#each easings as ez}
+          <option value={ez}>{ez}</option>  
+        {/each}
+      </select>
+    </div>
+
+    {#each Object.entries(transitions) as [title, groupedByShape]}
+      <h3>{title}</h3>
+      <dl>
+        {#each Object.entries(groupedByShape) as [direction, groupedByDirection]}
+          <dt>{direction}</dt>
+          {#each groupedByDirection as txn}
+            <dd selected={txn === transition}>
+              <a href="#{txn}" on:click={transitionClick}>{txn}</a>
+            </dd>
+          {/each}
+        {/each}
+      </dl>
+    {/each}
   </div>
-  
-  <a href="https://github.com/argyleink/transition.css#custom">Documentation ↗</a>
-  <a href="https://github.com/argyleink/transition.css/issues/new">Suggest a transition ↗</a>
-  <a href="https://github.com/argyleink/transition.css">Contribute ↗</a>
+  <div class="nav__footer">
+    <div class="nav__footer__icon">
+      <div class="icon-break">
+        <a href="https://github.com/argyleink/transition.css">
+          <svg viewbox="0 0 512 512">
+            {@html GithubSVG}
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div class="nav__footer__links">
+      <a href="https://github.com/argyleink/transition.css#custom">Documentation ↗</a>
+      <a href="https://github.com/argyleink/transition.css/issues/new">Suggest a transition ↗</a>
+      <a href="https://github.com/argyleink/transition.css">Contribute ↗</a>
+    </div>
+  </div>
 </nav>
 
 <style>
@@ -114,12 +108,10 @@
 
   nav {
     display: flex;
-    gap: 1ch;
-    padding: 3ch;
     box-sizing: border-box;
   }
 
-  nav > h3 {
+  nav h3 {
     color: var(--brand);
     font-size: 2.5rem;
     text-transform: capitalize;
@@ -128,8 +120,8 @@
     text-decoration-color: var(--brand-alt);
   }
 
-  nav > h3,
-  nav > h4 {
+  nav h3,
+  nav h4 {
     margin: 0;
   }
 
@@ -208,20 +200,7 @@
 
   @media (max-width: 1000px) {
     nav {
-      background: var(--brand);
-      inline-size: 100%;
-      place-content: center;
-    }
-
-    nav > *:not(.mobile-only) {
       display: none;
-    }
-
-    nav > select {
-      font-size: 1.25rem;
-      border: none;
-      background: var(--white);
-      width: min(100%, 300px);
     }
   }
 
@@ -229,16 +208,44 @@
     nav {
       flex-direction: column;
       max-block-size: 100vh;
+      overflow-y: hidden;
+      background: var(--surface);
+    }
+
+    nav h3:not(:first-of-type) {
+      margin-block-start: 2ch;
+    }
+
+    .nav__transitions {
+      flex: 1;
+
+      display: flex;
+      flex-direction: column;
+      gap: 1ch;
+
+      padding: 3ch;
       overflow-y: auto;
       overscroll-behavior-y: none;
     }
 
-    nav > .mobile-only {
-      display: none;
+    
+    .nav__footer {
+      flex: 0 0 auto;
+
+      display: flex;
+
+      border-top: 1px solid #fff6;
     }
 
-    nav > h3:not(:first-of-type) {
-      margin-block-start: 2ch;
+    .nav__footer__icon,
+    .nav__footer__links {
+      padding: 1.5ch;
+    }
+
+    .nav__footer__links {
+      display: flex;
+      flex-direction: column;
+      gap: 1ch;
     }
   }
 


### PR DESCRIPTION
_Completely_ speculative PR aiming to surface the docs a little more...

Essentially it pins the block of links to the foot of the sidebar so that they're visible from the start and remain visible as the user scrolls through the various transitions:
<img width="1552" alt="Screenshot 2020-09-02 at 18 22 44" src="https://user-images.githubusercontent.com/21795/92016023-a1225a00-ed49-11ea-91a8-9477190b9a0a.png">

Since the DOM structure has changed, the it seemed easier to move the select out of `nav` and into the `header`. The layout is fairly unaltered:
<img width="1508" alt="Screenshot 2020-09-02 at 18 26 23" src="https://user-images.githubusercontent.com/21795/92016492-4f2e0400-ed4a-11ea-9324-8606b15a4df0.png">
